### PR TITLE
Revert "chore(deps): bump python from 3.9.7-slim to 3.10.0-slim"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.0-slim
+FROM python:3.9.7-slim
 
 RUN apt-get update && \
     apt-cache madison git | awk '{print $3}'| xargs -i apt-get install -y --no-install-recommends git={} && \


### PR DESCRIPTION
Reverts BobAnkh/auto-generate-changelog#68